### PR TITLE
App SMTP TLS Support in .env

### DIFF
--- a/config/.env.default
+++ b/config/.env.default
@@ -69,6 +69,7 @@ export SMTP_HOST="smtp.example.com"
 export SMTP_PORT="587"
 export SMTP_USERNAME=""
 export SMTP_PASSWORD=""
+export SMTP_TLS="false"
 export EMAIL_FROM="you@localhost"
 
 ########################

--- a/config/app.php
+++ b/config/app.php
@@ -330,7 +330,7 @@ return [
 			'password' => env('SMTP_PASSWORD'),
 			'timeout' => 30,
 			'client' => null,
-			'tls' => null,
+			'tls' => env('SMTP_TLS'),
 			'url' => env('EMAIL_TRANSPORT_DEFAULT_URL', null),
 		],
 		// When the system is in debug mode, all email is written into the 'email' flash message


### PR DESCRIPTION
ZOHO SMTP needs TLS, other providers need as well. This change worked for me, so I decided to share!