### PR TITLE
Fix mysql-client docker build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-apache
+FROM php:7-apache-buster
 
 #install all the system dependencies and enable PHP modules 
 RUN apt-get update && apt-get install -y \
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y \
       libmcrypt-dev \
       zlib1g-dev \
       libzip-dev \
-      mysql-client \
+      default-mysql-client \
       git \
       zip \
       unzip \


### PR DESCRIPTION
The php:7-apache base image changed from stretch to buster (see
https://github.com/docker-library/repo-info/commit/0009f4023f5f42d888d951300642e721ed055fe8#diff-edda75275fec1a856fb45c7343a090d5),
which no longer has a mysql-client package, breaking the docker build.

Fixes the package name and pins to buster to prevent similar issues.