### PR TITLE
Fix "pecl/mcrypt is not compatible with PHP version 7.4.0"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-apache-buster
+FROM php:7.3-apache-buster
 
 #install all the system dependencies and enable PHP modules 
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
php:7-apache-buster moved to PHP 7.4.0, which pecl/mcrypt
fails to install on. Pin to 7.3 to make it work for now.