### PR TITLE
Fix CI test suite

### DIFF
--- a/tests/Factory/IncidentFactory.php
+++ b/tests/Factory/IncidentFactory.php
@@ -1,0 +1,33 @@
+<?php
+namespace App\Test\Factory;
+
+use CakephpFixtureFactories\Factory\BaseFactory;
+use Faker\Generator;
+
+class IncidentFactory extends BaseFactory
+{
+	/**
+	 * Defines the Table Registry used to generate entities with
+	 * @return string
+	 */
+	protected function getRootTableRegistryName(): string
+	{
+		return 'Incidents';
+	}
+
+	/**
+	 * Defines the default values of you factory. Useful for
+	 * not nullable fields.
+	 * Use the patchData method to set the field values.
+	 * You may use methods of the factory here
+	 */
+	protected function setDefaultTemplate(): void
+	{
+		$this->setDefaultData(function(Generator $faker) {
+			return [
+				'type' => 'Other',
+				'details' => $faker->sentence(),
+			];
+		});
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,7 +20,6 @@ use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Mysql;
 use Cake\Datasource\ConnectionManager;
-use Cake\Routing\Router;
 use Migrations\TestSuite\Migrator;
 
 /**
@@ -35,20 +34,20 @@ define('CACHE_PREFIX', 'cli_');
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 define('PHPUNIT_TESTSUITE', true);
-require dirname(__DIR__) . '/config/bootstrap.php';
 
-if (empty($_SERVER['HTTP_HOST']) && !Configure::read('App.fullBaseUrl')) {
-    Configure::write('App.fullBaseUrl', 'http://localhost');
-	// config/bootstrap.php ran above before HTTP_HOST was set, so Router never picked up
-	// a base URL. Set it explicitly here so Router::url(..., true) generates valid absolute URLs.
-	Router::fullBaseUrl('http://localhost');
-
+// Under the CLI SAPI there is no HTTP_HOST, so config/bootstrap.php would compute an
+// empty Router base URL ('http://'). Router::url(..., true) then yields malformed URLs
+// like 'http:///users/login', which parse_url() rejects, breaking the unauthenticated
+// redirect (it collapses to '/'). Set a host before bootstrapping so the base URL is valid.
+if (empty($_SERVER['HTTP_HOST'])) {
 	$_SERVER['PHP_SELF'] = '/index.php';
 	$_SERVER['SERVER_NAME'] = 'test.zuluru.org';
 	$_SERVER['HTTP_HOST'] = 'test.zuluru.org';
 	$_SERVER['REQUEST_SCHEME'] = 'https';
-	$_SERVER['HTTPS'] = 1;
+	$_SERVER['HTTPS'] = 'on';
 }
+
+require dirname(__DIR__) . '/config/bootstrap.php';
 
 // DebugKit skips settings these connection config if PHP SAPI is CLI / PHPDBG.
 // But since PagesControllerTest is run with debug enabled and DebugKit is loaded


### PR DESCRIPTION
- Add the missing `tests/Factory/IncidentFactory.php`; `GamesControllerTest`
  references `IncidentFactory::make()` but the file was never committed,
  causing a fatal "Class not found" error
- Fix `tests/bootstrap.php` so `Router::url(..., true)` produces a valid
  absolute URL under the CLI SAPI: set `HTTP_HOST` before
  `config/bootstrap.php` runs, rather than after (when the empty Router base
  `http://` had already been cached)
- Without this, unauthenticated redirects resolved to `/` instead of
  `/users/login` because `parse_url('http:///users/login')` returns false,
  which the Authentication plugin falls back from to `/`
- Use the string `'on'` for `$_SERVER['HTTPS']` instead of the integer `1`,
  which the bundled Diactoros version rejects
- Remove the previous gated fix attempt (it never ran because `fullBaseUrl`
  was already set by the time its condition was checked) and the now-unused
  `Router` import