### PR TITLE
Silence empty Table test warnings

### DIFF
--- a/tests/TestCase/Model/Table/ActivityLogsTableTest.php
+++ b/tests/TestCase/Model/Table/ActivityLogsTableTest.php
@@ -34,4 +34,8 @@ class ActivityLogsTableTest extends TableTestCase {
 		parent::tearDown();
 	}
 
+	public function testInitialize(): void {
+		$this->markTestIncomplete('Not implemented yet.');
+	}
+
 }

--- a/tests/TestCase/Model/Table/AnswersTableTest.php
+++ b/tests/TestCase/Model/Table/AnswersTableTest.php
@@ -34,4 +34,8 @@ class AnswersTableTest extends TableTestCase {
 		parent::tearDown();
 	}
 
+	public function testInitialize(): void {
+		$this->markTestIncomplete('Not implemented yet.');
+	}
+
 }

--- a/tests/TestCase/Model/Table/AttendancesTableTest.php
+++ b/tests/TestCase/Model/Table/AttendancesTableTest.php
@@ -34,4 +34,8 @@ class AttendancesTableTest extends TableTestCase {
 		parent::tearDown();
 	}
 
+	public function testInitialize(): void {
+		$this->markTestIncomplete('Not implemented yet.');
+	}
+
 }

--- a/tests/TestCase/Model/Table/CreditsTableTest.php
+++ b/tests/TestCase/Model/Table/CreditsTableTest.php
@@ -34,4 +34,8 @@ class CreditsTableTest extends TableTestCase {
 		parent::tearDown();
 	}
 
+	public function testInitialize(): void {
+		$this->markTestIncomplete('Not implemented yet.');
+	}
+
 }

--- a/tests/TestCase/Model/Table/DaysTableTest.php
+++ b/tests/TestCase/Model/Table/DaysTableTest.php
@@ -34,4 +34,8 @@ class DaysTableTest extends TableTestCase {
 		parent::tearDown();
 	}
 
+	public function testInitialize(): void {
+		$this->markTestIncomplete('Not implemented yet.');
+	}
+
 }

--- a/tests/TestCase/Model/Table/DivisionsGameslotsTableTest.php
+++ b/tests/TestCase/Model/Table/DivisionsGameslotsTableTest.php
@@ -34,4 +34,8 @@ class DivisionsGameslotsTableTest extends TableTestCase {
 		parent::tearDown();
 	}
 
+	public function testInitialize(): void {
+		$this->markTestIncomplete('Not implemented yet.');
+	}
+
 }

--- a/tests/TestCase/Model/Table/FranchisesTeamsTableTest.php
+++ b/tests/TestCase/Model/Table/FranchisesTeamsTableTest.php
@@ -34,4 +34,8 @@ class FranchisesTeamsTableTest extends TableTestCase {
 		parent::tearDown();
 	}
 
+	public function testInitialize(): void {
+		$this->markTestIncomplete('Not implemented yet.');
+	}
+
 }

--- a/tests/TestCase/Model/Table/GamesAllstarsTableTest.php
+++ b/tests/TestCase/Model/Table/GamesAllstarsTableTest.php
@@ -34,4 +34,8 @@ class GamesAllstarsTableTest extends TableTestCase {
 		parent::tearDown();
 	}
 
+	public function testInitialize(): void {
+		$this->markTestIncomplete('Not implemented yet.');
+	}
+
 }

--- a/tests/TestCase/Model/Table/IncidentsTableTest.php
+++ b/tests/TestCase/Model/Table/IncidentsTableTest.php
@@ -34,4 +34,8 @@ class IncidentsTableTest extends TableTestCase {
 		parent::tearDown();
 	}
 
+	public function testInitialize(): void {
+		$this->markTestIncomplete('Not implemented yet.');
+	}
+
 }

--- a/tests/TestCase/Model/Table/LocksTableTest.php
+++ b/tests/TestCase/Model/Table/LocksTableTest.php
@@ -34,4 +34,8 @@ class LocksTableTest extends TableTestCase {
 		parent::tearDown();
 	}
 
+	public function testInitialize(): void {
+		$this->markTestIncomplete('Not implemented yet.');
+	}
+
 }

--- a/tests/TestCase/Model/Table/NoticesPeopleTableTest.php
+++ b/tests/TestCase/Model/Table/NoticesPeopleTableTest.php
@@ -34,4 +34,8 @@ class NoticesPeopleTableTest extends TableTestCase {
 		parent::tearDown();
 	}
 
+	public function testInitialize(): void {
+		$this->markTestIncomplete('Not implemented yet.');
+	}
+
 }

--- a/tests/TestCase/Model/Table/NoticesTableTest.php
+++ b/tests/TestCase/Model/Table/NoticesTableTest.php
@@ -34,4 +34,8 @@ class NoticesTableTest extends TableTestCase {
 		parent::tearDown();
 	}
 
+	public function testInitialize(): void {
+		$this->markTestIncomplete('Not implemented yet.');
+	}
+
 }

--- a/tests/TestCase/Model/Table/PoolsTableTest.php
+++ b/tests/TestCase/Model/Table/PoolsTableTest.php
@@ -34,4 +34,8 @@ class PoolsTableTest extends TableTestCase {
 		parent::tearDown();
 	}
 
+	public function testInitialize(): void {
+		$this->markTestIncomplete('Not implemented yet.');
+	}
+
 }

--- a/tests/TestCase/Model/Table/QuestionnairesQuestionsTableTest.php
+++ b/tests/TestCase/Model/Table/QuestionnairesQuestionsTableTest.php
@@ -34,4 +34,8 @@ class QuestionnairesQuestionsTableTest extends TableTestCase {
 		parent::tearDown();
 	}
 
+	public function testInitialize(): void {
+		$this->markTestIncomplete('Not implemented yet.');
+	}
+
 }

--- a/tests/TestCase/Model/Table/ScoreDetailStatsTableTest.php
+++ b/tests/TestCase/Model/Table/ScoreDetailStatsTableTest.php
@@ -34,4 +34,8 @@ class ScoreDetailStatsTableTest extends TableTestCase {
 		parent::tearDown();
 	}
 
+	public function testInitialize(): void {
+		$this->markTestIncomplete('Not implemented yet.');
+	}
+
 }

--- a/tests/TestCase/Model/Table/ScoreDetailsTableTest.php
+++ b/tests/TestCase/Model/Table/ScoreDetailsTableTest.php
@@ -34,4 +34,8 @@ class ScoreDetailsTableTest extends TableTestCase {
 		parent::tearDown();
 	}
 
+	public function testInitialize(): void {
+		$this->markTestIncomplete('Not implemented yet.');
+	}
+
 }

--- a/tests/TestCase/Model/Table/SubscriptionsTableTest.php
+++ b/tests/TestCase/Model/Table/SubscriptionsTableTest.php
@@ -34,4 +34,8 @@ class SubscriptionsTableTest extends TableTestCase {
 		parent::tearDown();
 	}
 
+	public function testInitialize(): void {
+		$this->markTestIncomplete('Not implemented yet.');
+	}
+
 }

--- a/tests/TestCase/Model/Table/TeamsFacilitiesTableTest.php
+++ b/tests/TestCase/Model/Table/TeamsFacilitiesTableTest.php
@@ -34,4 +34,8 @@ class TeamsFacilitiesTableTest extends TableTestCase {
 		parent::tearDown();
 	}
 
+	public function testInitialize(): void {
+		$this->markTestIncomplete('Not implemented yet.');
+	}
+
 }

--- a/tests/TestCase/Model/Table/WaiversPeopleTableTest.php
+++ b/tests/TestCase/Model/Table/WaiversPeopleTableTest.php
@@ -34,4 +34,8 @@ class WaiversPeopleTableTest extends TableTestCase {
 		parent::tearDown();
 	}
 
+	public function testInitialize(): void {
+		$this->markTestIncomplete('Not implemented yet.');
+	}
+
 }


### PR DESCRIPTION
- Add a `markTestIncomplete('Not implemented yet.')` placeholder method to
  the 19 bake-generated `*TableTest` stub classes that had no test methods
- These were each producing a "No tests found in class" warning in CI (19
  warnings total)
- Matches the convention already used by the other unimplemented Table tests
  (e.g. `DivisionsTableTest`); the warnings now report as incomplete instead