### PR TITLE
Fixed Dockerfile and Docker-Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,51 +1,38 @@
-FROM php:7.3-alpine
+FROM php:7.4-cli-bullseye
 
-#install all the system dependencies and enable PHP modules 
-RUN apk add --update \
-    autoconf \
-    git \
-    icu-dev \
-    libzip-dev \
-    php7-curl \
-    php7-intl \
-    php7-mbstring \
-    php7-mysqli \
-    php7-opcache \
-    php7-openssl \
-    php7-pdo_mysql \
-    php7-pdo_pgsql \
-    php7-pgsql \
-    php7-zip \
-    php7-zlib \
-    postgresql-dev \
-  && docker-php-ext-configure pdo_mysql --with-pdo-mysql=mysqlnd \
-  && docker-php-ext-install \
-    intl \
-    mbstring \
-    pcntl \
-    pdo_mysql \
-    pdo_pgsql \
-    pgsql \
-    zip \
-    opcache \
-  && rm -rf /var/cache/apk/*
+# System dependencies.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git \
+        unzip \
+        libicu-dev \
+        libonig-dev \
+        libzip-dev \
+        zlib1g-dev \
+        libpq-dev \
+        default-mysql-client \
+    && docker-php-ext-configure pdo_mysql --with-pdo-mysql=mysqlnd \
+    && docker-php-ext-install \
+        intl \
+        mbstring \
+        pcntl \
+        pdo_mysql \
+        pdo_pgsql \
+        pgsql \
+        zip \
+        opcache \
+    && rm -rf /var/lib/apt/lists/*
 
-#install composer
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer
+# Install Composer.
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
-COPY . /var/www/html
+ENV COMPOSER_HOME=/tmp/composer \
+    COMPOSER_CACHE_DIR=/tmp/composer/cache \
+    COMPOSER_ALLOW_SUPERUSER=1
+RUN mkdir -p /tmp/composer/cache && chmod -R 0777 /tmp/composer
 
 WORKDIR /var/www/html
-
-# install all PHP dependencies
-RUN composer install --no-interaction
-
-# Modify app.php file
-RUN sed -i -e "s/'SECURITY_SALT'/'SECURITY_SALT', '5C2Yi3REBrXA5cN06dcH6VdAeJySm6RR'/" config/app.php && \
-	# Make sessionhandler configurable via environment
-	sed -i -e "s/'php',/env('SESSION_DEFAULTS', 'php'),/" config/app.php
-	# Set write permissions for webserver
-
-EXPOSE 80
-
-CMD bin/cake server -H 0.0.0.0 -p 80
+COPY docker/entrypoint.sh /usr/local/bin/zuluru-entrypoint
+RUN chmod +x /usr/local/bin/zuluru-entrypoint
+EXPOSE 8080
+ENTRYPOINT ["/usr/local/bin/zuluru-entrypoint"]
+CMD ["bin/cake", "server", "-H", "0.0.0.0", "-p", "8080"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,7 @@
-version: "3.7"
 services:
   db:
     image: mariadb:10.5
-    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --sql-mode=
     environment:
       MYSQL_ROOT_PASSWORD: rootpassword
       MYSQL_DATABASE: zuluru
@@ -16,10 +15,26 @@ services:
   app:
     image: zuluru/zuluru:latest
     build: .
+    user: "1000:1000"
     volumes:
-      - app:/var/www/html
+      - .:/var/www/html
+    environment:
+      APP_NAME: Zuluru
+      DEBUG: "true"
+      SECURITY_SALT: "5C2Yi3REBrXA5cN06dcH6VdAeJySm6RR"
+      APP_DEFAULT_TIMEZONE: UTC
+      APP_DEFAULT_LOCALE: en_US
+      FIELD_NAME: field
+      SQL_DRIVER: Mysql
+      SQL_HOSTNAME: db
+      SQL_USERNAME: zuluru
+      SQL_PASSWORD: userpassword
+      SQL_DATABASE: zuluru
+      EMAIL_TRANSPORT: Mail
+      EMAIL_FROM: "you@localhost"
+      HOME: /tmp
     ports:
-      - "80:80"
+      - "8080:8080"
     depends_on:
       - db
     networks:
@@ -27,7 +42,6 @@ services:
 
 volumes:
   db:
-  app:
 
 networks:
   default:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -e
+
+APP_DIR=/var/www/html
+cd "$APP_DIR"
+
+echo "[entrypoint] Ensuring writable directories exist..."
+mkdir -p \
+    tmp/cache/models \
+    tmp/cache/persistent \
+    tmp/cache/views \
+    tmp/sessions \
+    tmp/tests \
+    logs
+
+if [ ! -f vendor/autoload.php ]; then
+    echo "[entrypoint] vendor/ not found -- installing PHP libraries with composer..."
+    composer install --no-interaction --no-progress
+else
+    echo "[entrypoint] vendor/ present -- skipping composer install."
+fi
+
+echo "[entrypoint] Starting: $*"
+exec "$@"


### PR DESCRIPTION
This fix make it possible to run with a single command:

```bash
sudo docker compose up -d
```

Keeping the application files outside the container (bind-mount). So, the application decouples from the system+dependencies.